### PR TITLE
Fix README URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ A simplified version of the WingFoil Progress Tracker application with a clean s
    python run.py
    ```
 
-3. Access the application in your browshttp://127.0.0.1:5009/er at:
+3. Access the application in your browser at:
    ```
-   http://127.0.0.1:5009
+   http://127.0.0.1:5000
    ```
 
 ## Structure


### PR DESCRIPTION
## Summary
- fix the phrase for how to access the running app
- update the example URL to port 5000

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68427ff87ea88331bb358a04098bff46