### PR TITLE
Enable user session media uploads

### DIFF
--- a/templates/pages/training/session_detail.html
+++ b/templates/pages/training/session_detail.html
@@ -223,7 +223,7 @@
             
             <!-- Edit Mode -->
             <div id="editForm" class="card-body p-4 edit-form">
-                <form id="sessionEditForm" method="POST" action="{{ url_for('admin.admin_session_detail', session_id=session.id) }}" enctype="multipart/form-data">
+                <form id="sessionEditForm" method="POST" action="{{ url_for('training.update_session') }}" enctype="multipart/form-data">
                     <input type="hidden" name="session_id" value="{{ session.id }}">
                     
                     <div class="row">


### PR DESCRIPTION
## Summary
- allow editing sessions via training.update_session from session_detail page
- load learning materials alongside images in session detail
- support image uploads and YouTube material when regular users update sessions

## Testing
- `python -m py_compile app.py models.py product_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6843f10c8f908331b82a02895430d1f4