### PR TITLE
Enable hover for training submenu

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -111,4 +111,23 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
     }
+
+    // Hover dropdown for training material
+    const trainingMaterialTrigger = document.getElementById('trainingMaterialDropdown');
+    if (trainingMaterialTrigger) {
+        const dropdownMenu = trainingMaterialTrigger.nextElementSibling;
+        const dropdownInstance = bootstrap.Dropdown.getOrCreateInstance(trainingMaterialTrigger);
+
+        trainingMaterialTrigger.addEventListener('mouseenter', () => dropdownInstance.show());
+
+        trainingMaterialTrigger.addEventListener('mouseleave', (e) => {
+            if (!dropdownMenu.contains(e.relatedTarget)) {
+                dropdownInstance.hide();
+            }
+        });
+
+        if (dropdownMenu) {
+            dropdownMenu.addEventListener('mouseleave', () => dropdownInstance.hide());
+        }
+    }
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
                         <a class="nav-link dropdown-toggle" href="#" id="trainingDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Training
                         </a>
-                        <ul class="dropdown-menu" aria-labelledby="trainingDropdown">
+                            <ul class="dropdown-menu" aria-labelledby="trainingDropdown" data-bs-auto-close="outside">
                             <li><a class="dropdown-item" href="{{ url_for('training.stats') }}">Dashboard</a></li>
                             <li><a class="dropdown-item" href="{{ url_for('training.log_session') }}">Log Session</a></li>
                             <li class="dropend">


### PR DESCRIPTION
## Summary
- keep dropdown markup but allow clicking outside to close
- support hover interactions for the Training Material submenu

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843f3cc13188331a11c7690c6ee7483