### PR TITLE
Add skill management update route

### DIFF
--- a/models.py
+++ b/models.py
@@ -121,3 +121,15 @@ class ProductImage(db.Model):
     product_id = db.Column(db.Integer, db.ForeignKey('product.id'), nullable=False)
     image_url = db.Column(db.String, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+# Track the status of a skill for a user
+class UserSkillStatus(db.Model):
+    __tablename__ = 'user_skill_status'
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    skill_id = db.Column(db.Integer, db.ForeignKey('skill.id'), nullable=False)
+    status = db.Column(db.String(20), nullable=False)  # 'mastered' or 'in_progress'
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship('User', backref=db.backref('skill_statuses', lazy=True))
+    skill = db.relationship('Skill', backref=db.backref('user_statuses', lazy=True))

--- a/templates/pages/training/stats.html
+++ b/templates/pages/training/stats.html
@@ -174,6 +174,56 @@
             </div>
         </div>
     </div>
+
+    <!-- Skills Management Section -->
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Skills in Progress</h5>
+                </div>
+                <div class="card-body p-0">
+                    <ul class="list-group list-group-flush">
+                        {% for status in inprogress_skills %}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            {{ status.skill.name }}
+                            <form method="post" action="{{ url_for('training.update_skill_status') }}" class="ms-3">
+                                <input type="hidden" name="skill_id" value="{{ status.skill.id }}">
+                                <input type="hidden" name="new_status" value="mastered">
+                                <button type="submit" class="btn btn-sm btn-success">Mark Mastered</button>
+                            </form>
+                        </li>
+                        {% else %}
+                        <li class="list-group-item text-muted">No skills in progress</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Skills Mastered</h5>
+                </div>
+                <div class="card-body p-0">
+                    <ul class="list-group list-group-flush">
+                        {% for status in mastered_skills %}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            {{ status.skill.name }}
+                            <form method="post" action="{{ url_for('training.update_skill_status') }}" class="ms-3">
+                                <input type="hidden" name="skill_id" value="{{ status.skill.id }}">
+                                <input type="hidden" name="new_status" value="in_progress">
+                                <button type="submit" class="btn btn-sm btn-secondary">Move to Progress</button>
+                            </form>
+                        </li>
+                        {% else %}
+                        <li class="list-group-item text-muted">No mastered skills yet</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <!-- Add Goal Modal -->


### PR DESCRIPTION
## Summary
- add `UserSkillStatus` model for tracking skill progress
- query skill statuses in training dashboard
- add route to update a skill's status
- render Skills Mastered and Skills in Progress lists on dashboard

## Testing
- `python -m py_compile models.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6843f88977bc83319c8991044a432cce