### PR TITLE
Update landing CTA

### DIFF
--- a/templates/pages/index_updated.html
+++ b/templates/pages/index_updated.html
@@ -210,7 +210,7 @@
 <section class="hero-section mb-5">
   <img src="{{ url_for('static', filename='img/logosolo.png') }}" alt="Logo Solo" class="hero-logo mb-4">
   <p class="lead mb-4 text-dark">Take lessons, track your wingfoil sessions, and conquer the wingfoil with Wingsalsa.</p>
-  <a href="{{ url_for('main.gear') }}" class="btn btn-outline-primary mt-auto">Ver más</a>
+  <a href="{{ url_for('auth.register') }}" class="btn btn-cta mt-auto">Regístrate y comienza</a>
 </section>
 
 <!-- Features Section -->


### PR DESCRIPTION
## Summary
- replace the "Ver más" button on the landing hero with a sign-up call-to-action

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844394802108331b7b2dddda429ba57