### PR TITLE
Implement chat history logging

### DIFF
--- a/migrations/versions/20250608_add_chat_message.py
+++ b/migrations/versions/20250608_add_chat_message.py
@@ -1,0 +1,27 @@
+"""add chat message model
+Revision ID: 20250608_add_chat_message
+Revises: ad3be3ec7e1c
+Create Date: 2025-06-08
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '20250608_add_chat_message'
+down_revision = 'ad3be3ec7e1c'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'chat_message',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=True),
+        sa.Column('role', sa.String(length=10), nullable=False),
+        sa.Column('content', sa.Text(), nullable=False),
+        sa.Column('timestamp', sa.DateTime(), nullable=True, server_default=sa.func.now())
+    )
+
+
+def downgrade():
+    op.drop_table('chat_message')

--- a/models.py
+++ b/models.py
@@ -132,3 +132,13 @@ class ProductImage(db.Model):
     image_url = db.Column(db.String, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
+# Chat history model
+class ChatMessage(db.Model):
+    __tablename__ = 'chat_message'
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    role = db.Column(db.String(10), nullable=False)  # 'user' or 'assistant'
+    content = db.Column(db.Text, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user = db.relationship('User', backref=db.backref('chat_messages', lazy='dynamic'))
+


### PR DESCRIPTION
## Summary
- add `ChatMessage` SQLAlchemy model
- create Alembic migration for chat messages
- log user and assistant messages in `chat_api`
- expose optional `/agent/history` endpoint to fetch recent chat

## Testing
- `python -m py_compile models.py agent.py migrations/versions/20250608_add_chat_message.py`


------
https://chatgpt.com/codex/tasks/task_e_68443d4697308331a752a395ccd2ad39