### PR TITLE
Add index for chat message sessions

### DIFF
--- a/migrations/versions/a9f6525ebfb1_add_session_id_index.py
+++ b/migrations/versions/a9f6525ebfb1_add_session_id_index.py
@@ -1,0 +1,21 @@
+"""add index on chat_message.session_id
+
+Revision ID: a9f6525ebfb1
+Revises: dfbeffe02eb5
+Create Date: 2025-06-09 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'a9f6525ebfb1'
+down_revision = 'dfbeffe02eb5'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_index('ix_chat_message_session_id', 'chat_message', ['session_id'])
+
+
+def downgrade():
+    op.drop_index('ix_chat_message_session_id', table_name='chat_message')


### PR DESCRIPTION
## Summary
- create migration to add `ix_chat_message_session_id` index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452dd1a7248331bfc0bae5e4c8eb85