### PR TITLE
Update training skills section position

### DIFF
--- a/templates/pages/training/stats.html
+++ b/templates/pages/training/stats.html
@@ -65,6 +65,56 @@
         </div>
     </div>
 
+    <!-- Skills Management Section -->
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Skills in Progress</h5>
+                </div>
+                <div class="card-body p-0">
+                    <ul class="list-group list-group-flush">
+                        {% for status in inprogress_skills %}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            {{ status.skill.name }}
+                            <form method="post" action="{{ url_for('training.update_skill_status') }}" class="ms-3">
+                                <input type="hidden" name="skill_id" value="{{ status.skill.id }}">
+                                <input type="hidden" name="new_status" value="mastered">
+                                <button type="submit" class="btn btn-sm btn-success">Mark Mastered</button>
+                            </form>
+                        </li>
+                        {% else %}
+                        <li class="list-group-item text-muted">No skills in progress</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Skills Mastered</h5>
+                </div>
+                <div class="card-body p-0">
+                    <ul class="list-group list-group-flush">
+                        {% for status in mastered_skills %}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            {{ status.skill.name }}
+                            <form method="post" action="{{ url_for('training.update_skill_status') }}" class="ms-3">
+                                <input type="hidden" name="skill_id" value="{{ status.skill.id }}">
+                                <input type="hidden" name="new_status" value="in_progress">
+                                <button type="submit" class="btn btn-sm btn-secondary">Move to Progress</button>
+                            </form>
+                        </li>
+                        {% else %}
+                        <li class="list-group-item text-muted">No mastered skills yet</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="row">
         <!-- Training Sessions Section - Full Width -->
         <div class="col-12">
@@ -175,55 +225,6 @@
         </div>
     </div>
 
-    <!-- Skills Management Section -->
-    <div class="row mb-4">
-        <div class="col-md-6">
-            <div class="card shadow-sm">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0">Skills in Progress</h5>
-                </div>
-                <div class="card-body p-0">
-                    <ul class="list-group list-group-flush">
-                        {% for status in inprogress_skills %}
-                        <li class="list-group-item d-flex justify-content-between align-items-center">
-                            {{ status.skill.name }}
-                            <form method="post" action="{{ url_for('training.update_skill_status') }}" class="ms-3">
-                                <input type="hidden" name="skill_id" value="{{ status.skill.id }}">
-                                <input type="hidden" name="new_status" value="mastered">
-                                <button type="submit" class="btn btn-sm btn-success">Mark Mastered</button>
-                            </form>
-                        </li>
-                        {% else %}
-                        <li class="list-group-item text-muted">No skills in progress</li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-6">
-            <div class="card shadow-sm">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0">Skills Mastered</h5>
-                </div>
-                <div class="card-body p-0">
-                    <ul class="list-group list-group-flush">
-                        {% for status in mastered_skills %}
-                        <li class="list-group-item d-flex justify-content-between align-items-center">
-                            {{ status.skill.name }}
-                            <form method="post" action="{{ url_for('training.update_skill_status') }}" class="ms-3">
-                                <input type="hidden" name="skill_id" value="{{ status.skill.id }}">
-                                <input type="hidden" name="new_status" value="in_progress">
-                                <button type="submit" class="btn btn-sm btn-secondary">Move to Progress</button>
-                            </form>
-                        </li>
-                        {% else %}
-                        <li class="list-group-item text-muted">No mastered skills yet</li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        </div>
-    </div>
 </div>
 
 <!-- Add Goal Modal -->


### PR DESCRIPTION
## Summary
- reposition skill tables under the dashboard on the training page

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d8994152c8331a1e152ad77a18f1f