### PR TITLE
Reorder training goals card

### DIFF
--- a/templates/pages/training/stats.html
+++ b/templates/pages/training/stats.html
@@ -121,6 +121,68 @@
         </div>
     </div>
 
+    <!-- Goals Section - Now Horizontal -->
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-light d-flex justify-content-between align-items-center">
+                    <h3 class="mb-0">Training Goals</h3>
+                    <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#addGoalModal">
+                        <i class="bi bi-plus-lg"></i> Add Goal
+                    </button>
+                </div>
+                <div class="card-body">
+                    {% if goals %}
+                        <div class="row">
+                            {% for goal in goals %}
+                                <div class="col-12 col-md-6 col-lg-4 mb-3">
+                                    <div class="card h-100 border-0 shadow-sm">
+                                        <div class="card-body">
+                                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                                <h5 class="card-title mb-0">{{ goal.title }}</h5>
+                                                <div class="dropdown">
+                                                    <button class="btn btn-sm btn-link text-dark" type="button" id="goalDropdown{{ goal.id }}" data-bs-toggle="dropdown" aria-expanded="false">
+                                                        <i class="bi bi-three-dots-vertical"></i>
+                                                    </button>
+                                                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="goalDropdown{{ goal.id }}">
+                                                        <li><button class="dropdown-item edit-goal-btn" data-goal-id="{{ goal.id }}" data-progress="{{ goal.progress }}"><i class="bi bi-pencil me-2"></i>Edit Goal</button></li>
+                                                        <li><button class="dropdown-item delete-goal-btn" data-goal-id="{{ goal.id }}"><i class="bi bi-trash me-2"></i>Delete</button></li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                            <p class="card-text text-muted small mb-2">{{ goal.description }}</p>
+                                            <div class="d-flex justify-content-end align-items-center mb-2">
+                                                <small class="text-muted">Target: {{ goal.target_date }}</small>
+                                            </div>
+                                            <div class="progress" style="height: 10px;">
+                                                <div class="progress-bar bg-success" role="progressbar" style="width:{{ goal.progress }}%; min-width: 2em;" aria-valuenow="{{ goal.progress }}" aria-valuemin="0" aria-valuemax="100"></div>
+                                            </div>
+                                            <div class="d-flex justify-content-between mt-1">
+                                                <small class="text-muted">Progress</small>
+                                                <small class="text-muted">{{ goal.progress }}%</small>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <div class="text-center py-4">
+                            <div class="mb-3">
+                                <i class="bi bi-flag fs-1 text-muted"></i>
+                            </div>
+                            <h5>No Goals Yet</h5>
+                            <p class="text-muted">Set goals to track your wingfoil progress</p>
+                            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addGoalModal">
+                                <i class="bi bi-plus-lg"></i> Add Your First Goal
+                            </button>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="row">
         <!-- Training Sessions Section - Full Width -->
         <div class="col-12">
@@ -167,70 +229,6 @@
             </div>
         </div>
         
-        <!-- Goals Section - Now Horizontal -->
-        <div class="row mb-4">
-            <div class="col-12">
-                <div class="card shadow-sm h-100">
-                    <div class="card-header bg-light d-flex justify-content-between align-items-center">
-                        <h3 class="mb-0">Training Goals</h3>
-                        <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#addGoalModal">
-                            <i class="bi bi-plus-lg"></i> Add Goal
-                        </button>
-                    </div>
-                    <div class="card-body">
-                        {% if goals %}
-                            <div class="row">
-                                {% for goal in goals %}
-                                    <div class="col-12 col-md-6 col-lg-4 mb-3">
-                                        <div class="card h-100 border-0 shadow-sm">
-                                            <div class="card-body">
-                                                <div class="d-flex justify-content-between align-items-center mb-2">
-                                                    <h5 class="card-title mb-0">{{ goal.title }}</h5>
-                                                    <div class="dropdown">
-                                                        <button class="btn btn-sm btn-link text-dark" type="button" id="goalDropdown{{ goal.id }}" data-bs-toggle="dropdown" aria-expanded="false">
-                                                            <i class="bi bi-three-dots-vertical"></i>
-                                                        </button>
-                                                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="goalDropdown{{ goal.id }}">
-                                                            <li><button class="dropdown-item edit-goal-btn" data-goal-id="{{ goal.id }}" data-progress="{{ goal.progress }}"><i class="bi bi-pencil me-2"></i>Edit Goal</button></li>
-                                                            <li><button class="dropdown-item delete-goal-btn" data-goal-id="{{ goal.id }}"><i class="bi bi-trash me-2"></i>Delete</button></li>
-                                                        </ul>
-                                                    </div>
-                                                </div>
-                                                <p class="card-text text-muted small mb-2">{{ goal.description }}</p>
-                                                <div class="d-flex justify-content-end align-items-center mb-2">
-                                                    <small class="text-muted">Target: {{ goal.target_date }}</small>
-                                                </div>
-                                                <div class="progress" style="height: 10px;">
-                                                    <div class="progress-bar bg-success" role="progressbar" style="width:{{ goal.progress }}%; min-width: 2em;" aria-valuenow="{{ goal.progress }}" aria-valuemin="0" aria-valuemax="100"></div>
-                                                </div>
-                                                <div class="d-flex justify-content-between mt-1">
-                                                    <small class="text-muted">Progress</small>
-                                                    <small class="text-muted">{{ goal.progress }}%</small>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                {% endfor %}
-                            </div>
-                        {% else %}
-                            <div class="text-center py-4">
-                                <div class="mb-3">
-                                    <i class="bi bi-flag fs-1 text-muted"></i>
-                                </div>
-                                <h5>No Goals Yet</h5>
-                                <p class="text-muted">Set goals to track your wingfoil progress</p>
-                                <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addGoalModal">
-                                    <i class="bi bi-plus-lg"></i> Add Your First Goal
-                                </button>
-                            </div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-</div>
 
 <!-- Add Goal Modal -->
 <div class="modal fade" id="addGoalModal" tabindex="-1" aria-labelledby="addGoalModalLabel" aria-hidden="true">


### PR DESCRIPTION
## Summary
- move Training Goals card right below the skills cards in `stats.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check .` *(fails: would reformat)*

------
https://chatgpt.com/codex/tasks/task_e_684d9a3f31988331b13c36b5234f72f2