### PR TITLE
Add skill progress summary on profile

### DIFF
--- a/templates/pages/auth/profile.html
+++ b/templates/pages/auth/profile.html
@@ -137,16 +137,49 @@
                                 <a href="{{ url_for('training.stats') }}" class="btn btn-outline-primary ms-2">
                                     <i class="bi bi-journal-text me-1"></i> View My Sessions
                                 </a>
-                                <a href="{{ url_for('training.log_session') }}" class="btn btn-outline-primary ms-2">
-                                    <i class="bi bi-plus-circle me-1"></i> Log New Session
-                                </a>
-                            </div>
-                        </form>
+                            <a href="{{ url_for('training.log_session') }}" class="btn btn-outline-primary ms-2">
+                                <i class="bi bi-plus-circle me-1"></i> Log New Session
+                            </a>
+                        </div>
+                    </form>
+
+                    <div class="row mt-5">
+                        <div class="col-md-6">
+                            <h4>Skills In Progress</h4>
+                            {% if skills_in_progress %}
+                                <ul class="list-group mb-3">
+                                    {% for sk in skills_in_progress %}
+                                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                                        {{ sk.name }}
+                                        <span class="badge bg-primary">{{ sk.avg }}/5</span>
+                                    </li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                <p class="text-muted">No skills in progress yet.</p>
+                            {% endif %}
+                        </div>
+                        <div class="col-md-6">
+                            <h4>Skills Mastered</h4>
+                            {% if skills_mastered %}
+                                <ul class="list-group mb-3">
+                                    {% for sk in skills_mastered %}
+                                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                                        {{ sk.name }}
+                                        <span class="badge bg-success">{{ sk.avg }}/5</span>
+                                    </li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                <p class="text-muted">No skills mastered yet.</p>
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
+</div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- show skill mastery stats on the profile page
- compute averaged skill ratings per user

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684e9066e0d083319f5802af386a7e0a