### PR TITLE
Add skill tracking fields to User model

### DIFF
--- a/migrations/versions/2025_05_30_add_skill_tracking_fields.py
+++ b/migrations/versions/2025_05_30_add_skill_tracking_fields.py
@@ -1,0 +1,26 @@
+"""Add skill tracking fields to User
+
+Revision ID: 20250530_add_skill_tracking_fields
+Revises: 20250529_add_product_images
+Create Date: 2025-05-30
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '20250530_add_skill_tracking_fields'
+down_revision = '20250529_add_product_images'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('skills_in_progress', sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column('skills_mastered', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('skills_mastered')
+        batch_op.drop_column('skills_in_progress')

--- a/models.py
+++ b/models.py
@@ -22,6 +22,10 @@ class User(db.Model):
     location = db.Column(db.String)
     wingfoiling_since = db.Column(db.String)
     wingfoil_level = db.Column(db.String)
+    # JSON array of skill IDs currently being learned
+    skills_in_progress = db.Column(db.Text)
+    # JSON array of skill IDs that have been mastered
+    skills_mastered = db.Column(db.Text)
     # Link to levels table
     wingfoil_level_id = db.Column(db.Integer, db.ForeignKey('level.id'), nullable=True)
     level = db.relationship('Level', backref=db.backref('users', lazy=True))


### PR DESCRIPTION
## Summary
- extend `User` model with `skills_in_progress` and `skills_mastered`
- add alembic migration for new user fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e958a7080833182fae150741fe055