### PR TITLE
Remove unused imports from app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,10 @@
 import os
-import sqlite3
 import json
-import re
-from datetime import datetime
 import requests
 import functools
+from datetime import datetime
 from werkzeug.security import generate_password_hash, check_password_hash
-from flask import Flask, g, render_template, request, redirect, url_for, flash, session, jsonify, Blueprint
+from flask import Flask, render_template, request, redirect, url_for, flash, session, jsonify, Blueprint
 from werkzeug.utils import secure_filename
 # from chatbot import ask_wingfoil_ai # Old chatbot
 from agent import agent_bp # New agent-based chatbot
@@ -15,7 +13,6 @@ import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 from uuid import uuid4
 from flask_migrate import Migrate
-import os
 from dotenv import load_dotenv
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- drop unused imports from `app.py`

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684eb1cbba7c83318e461d520f7fc469