### PR TITLE
Fix imports for backend app path

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -25,7 +25,7 @@ def create_app():
     """
     global _flask_app_cache
     if _flask_app_cache is None:
-        legacy_module = import_module('app')  # app.py en la raíz
+        legacy_module = import_module('backend.app')  # app.py en la raíz
         _flask_app_cache = getattr(legacy_module, 'app')
     return _flask_app_cache
 

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -13,6 +13,6 @@ def create_app():
     """Return the existing Flask app from the legacy root `app.py`."""
     global _app_cache
     if _app_cache is None:
-        legacy_mod = import_module('app')
+        legacy_mod = import_module('backend.app')
         _app_cache = getattr(legacy_mod, 'app')
     return _app_cache

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -110,6 +110,6 @@ def run_migrations_online():
 if context.is_offline_mode():
     run_migrations_offline()
 else:
-    from app import app
+    from backend.app import app
     with app.app_context():
         run_migrations_online()


### PR DESCRIPTION
## Summary
- correct module paths for legacy `app`
- update migration to load `backend.app`

## Testing
- `python -m flask --app backend.app db upgrade` *(fails: No module named flask)*

------
https://chatgpt.com/codex/tasks/task_e_684ee029c7c08331ad02e27ba6d11581