### PR TITLE
Update wsgi entrypoint references

### DIFF
--- a/docs/README_MIGRACIONES.md
+++ b/docs/README_MIGRACIONES.md
@@ -217,7 +217,7 @@ railway run python diagnose_migrations.py --environment production
 
 **Procfile**:
 ```
-web: flask db upgrade && gunicorn -w 4 -b 0.0.0.0:$PORT wsgi:application
+web: flask db upgrade && gunicorn -w 4 -b 0.0.0.0:$PORT backend.wsgi:application
 ```
 
 ### Variables de Entorno

--- a/railway.toml
+++ b/railway.toml
@@ -1,4 +1,4 @@
 [build]
 
 [deploy]
-startCommand = "flask db upgrade && gunicorn -w 4 -b 0.0.0.0:$PORT wsgi:application"
+startCommand = "flask db upgrade && gunicorn -w 4 -b 0.0.0.0:$PORT backend.wsgi:application"


### PR DESCRIPTION
## Summary
- update Railway `startCommand` to point to `backend.wsgi:application`
- update deployment docs to show `backend.wsgi:application` in sample Procfile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee08527f48331b10b8d441459e108