### PR TITLE
Guard seed master endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1098,24 +1098,30 @@ os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 os.makedirs(app.config['CHAT_IMAGES_FOLDER'], exist_ok=True)
 
 # --- Endpoint temporal protegido para seed de datos maestros ---
-@app.route('/seed-master-data', methods=['POST'])
-def seed_master_data_endpoint():
-    """
-    Endpoint temporal para ejecutar el seed de datos maestros SOLO si se provee la clave secreta correcta.
-    Debe eliminarse tras su uso en producción.
-    Uso:
-        curl -X POST https://<tu-dominio>/seed-master-data -H "X-Seed-Secret: <TU_SEED_SECRET>"
-    """
-    SECRET = os.environ.get('SEED_MASTER_SECRET', 'cambia-esto')
-    client_secret = request.headers.get('X-Seed-Secret')
-    if not client_secret or client_secret != SECRET:
-        return jsonify({'error': 'Unauthorized'}), 401
-    try:
-        from seed_master_data import seed_master_data
-        seed_master_data()
-        return jsonify({'status': 'ok', 'message': 'Seed ejecutado correctamente'}), 200
-    except Exception as e:
-        return jsonify({'status': 'error', 'error': str(e)}), 500
+# Solo se habilita si la variable de entorno ENABLE_SEED_MASTER_ENDPOINT
+# está establecida en "1".
+if os.environ.get('ENABLE_SEED_MASTER_ENDPOINT') == '1':
+    @app.route('/seed-master-data', methods=['POST'])
+    def seed_master_data_endpoint():
+        """
+        Endpoint temporal para ejecutar el seed de datos maestros SOLO si se
+        provee la clave secreta correcta. Deshabilitado por defecto para evitar
+        que pueda usarse en producción.
+
+        Uso:
+            curl -X POST https://<tu-dominio>/seed-master-data \
+                -H "X-Seed-Secret: <TU_SEED_SECRET>"
+        """
+        SECRET = os.environ.get('SEED_MASTER_SECRET', 'cambia-esto')
+        client_secret = request.headers.get('X-Seed-Secret')
+        if not client_secret or client_secret != SECRET:
+            return jsonify({'error': 'Unauthorized'}), 401
+        try:
+            from seed_master_data import seed_master_data
+            seed_master_data()
+            return jsonify({'status': 'ok', 'message': 'Seed ejecutado correctamente'}), 200
+        except Exception as e:
+            return jsonify({'status': 'error', 'error': str(e)}), 500
 
 # Chatbot API route
 # @app.route('/api/chat', methods=['POST'])

--- a/docs/README_MIGRACIONES.md
+++ b/docs/README_MIGRACIONES.md
@@ -132,32 +132,21 @@ railway run python seed_master_data.py
 > curl -X POST https://www.wingsalsa.com/seed-master-data -H "X-Seed-Secret: mi_clave_supersecreta"
 > ```
 >
-> - Define la clave secreta en la variable de entorno `SEED_MASTER_SECRET` en Railway.
-> - El endpoint debe eliminarse tras su uso en producción para máxima seguridad.
+- Define la clave secreta en la variable de entorno `SEED_MASTER_SECRET` en Railway.
+- El endpoint solo está disponible si `ENABLE_SEED_MASTER_ENDPOINT=1`.
+- Asegúrate de deshabilitar esa variable tras ejecutarlo en producción para máxima seguridad.
 
 ---
 
-### 🚨 Instrucciones para eliminar el endpoint temporal de seed
+### 🚨 Instrucciones para habilitar temporalmente el endpoint de seed
 
-1. **Ubica el bloque de código en `backend/app.py` que contiene:**
-   ```python
-   @app.route('/seed-master-data', methods=['POST'])
-   def seed_master_data_endpoint():
-       ...
-   ```
-2. **Elimina todo el bloque del endpoint** (desde `@app.route...` hasta el final de la función).
-3. **Haz commit y push de los cambios a producción.**
-4. **Verifica que ya no existe el endpoint accediendo a:**
-   ```bash
-   curl -X POST https://www.wingsalsa.com/seed-master-data -H "X-Seed-Secret: TU_CLAVE_SECRETA"
-   # Debe responder 404 Not Found
-   ```
+1. Define `ENABLE_SEED_MASTER_ENDPOINT=1` en las variables de entorno de tu despliegue.
+2. Ejecuta el seed mediante el endpoint protegido.
+3. Elimina o cambia a `0` la variable `ENABLE_SEED_MASTER_ENDPOINT` para deshabilitarlo nuevamente.
 
 #### Checklist seguro para seed en producción
 - [ ] Ejecutar el seed usando el endpoint temporal protegido
-- [ ] Eliminar el bloque del endpoint de `backend/app.py`
-- [ ] Hacer commit y push de la eliminación
-- [ ] Verificar que el endpoint ya no está accesible
+- [ ] Deshabilitar la variable `ENABLE_SEED_MASTER_ENDPOINT` tras su uso
 
 
 ### 4. Merge a Producción


### PR DESCRIPTION
## Summary
- protect `seed-master-data` endpoint with an env flag
- document how to enable/disable the endpoint

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684eef52283883319fcfe4540c6df3b4