### PR TITLE
Add energy level columns

### DIFF
--- a/docs/README_MIGRACIONES.md
+++ b/docs/README_MIGRACIONES.md
@@ -76,6 +76,8 @@ Desarrollo Local → Railway Dev → Validación → Merge → Railway Prod
 - `falls_count` (Integer)
 - `jibes_count` (Integer)
 - `jumps_count` (Integer)
+- `energy_level_before` (Integer)
+- `energy_level_after` (Integer)
 
 ### Cadena de Dependencias:
 ```
@@ -344,7 +346,7 @@ badge (id, name, description, icon, category, criteria, points_value, rarity)
 user_badge (id, user_id, badge_id, unlocked_at)
 
 -- Sesiones extendidas
-session (id, user_id, ..., duration_minutes, distance_km, falls_count, jibes_count, jumps_count)
+session (id, user_id, ..., duration_minutes, distance_km, falls_count, jibes_count, jumps_count, energy_level_before, energy_level_after)
 ```
 
 ### Relaciones

--- a/migrations/versions/20250616_split_energy_level.py
+++ b/migrations/versions/20250616_split_energy_level.py
@@ -1,0 +1,50 @@
+"""split energy level column
+
+Revision ID: 20250616_split_energy_level
+Revises: 20250615_companion
+Create Date: 2025-06-16 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision = '20250616_split_energy_level'
+down_revision = '20250615_companion'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    session_columns = [col['name'] for col in inspector.get_columns('session')]
+
+    if 'energy_level_before' not in session_columns:
+        if 'energy_level' in session_columns:
+            op.alter_column('session', 'energy_level', new_column_name='energy_level_before')
+        else:
+            op.add_column('session', sa.Column('energy_level_before', sa.Integer(), nullable=True))
+
+    if 'energy_level_after' not in session_columns:
+        op.add_column('session', sa.Column('energy_level_after', sa.Integer(), nullable=True))
+
+    # If energy_level still exists after operations, drop it as obsolete
+    session_columns = [col['name'] for col in inspector.get_columns('session')]
+    if 'energy_level' in session_columns:
+        op.drop_column('session', 'energy_level')
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    session_columns = [col['name'] for col in inspector.get_columns('session')]
+
+    if 'energy_level_after' in session_columns:
+        op.drop_column('session', 'energy_level_after')
+
+    if 'energy_level_before' in session_columns:
+        if 'energy_level' not in session_columns:
+            op.alter_column('session', 'energy_level_before', new_column_name='energy_level')
+        else:
+            op.drop_column('session', 'energy_level_before')


### PR DESCRIPTION
## Summary
- add new Alembic migration to split `energy_level` into `energy_level_before` and `energy_level_after`
- document the new columns in README_MIGRACIONES

## Testing
- `python -m py_compile migrations/versions/20250616_split_energy_level.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef4524c6c833195d94bca61255d72