### PR TITLE
Remove print debug statements

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -355,14 +355,14 @@ def log_session():
         session_id = new_session.id
         
         # Depuración: loggear archivos recibidos
-        print('Archivos recibidos:', request.files)
-        print('Lista de imágenes:', request.files.getlist('images'))
+        app.logger.debug('Archivos recibidos: %s', request.files)
+        app.logger.debug('Lista de imágenes: %s', request.files.getlist('images'))
         # Handle images
         for f in request.files.getlist('images'):
-            print('Procesando archivo:', f.filename)
+            app.logger.debug('Procesando archivo: %s', f.filename)
             if f and allowed_file(f.filename):
                 url = upload_file_to_s3(f, app.config['S3_BUCKET'])
-                print('URL subida:', url)
+                app.logger.debug('URL subida: %s', url)
                 if url:
                     img = SessionImage(session_id=session_id, url=url)
                     db.session.add(img)
@@ -1189,9 +1189,9 @@ def initialize_database():
             )
             db.session.add(admin)
             db.session.commit()
-            print("Usuario admin creado automáticamente.")
+            app.logger.info("Usuario admin creado automáticamente.")
         else:
-            print("El usuario admin ya existe.")
+            app.logger.info("El usuario admin ya existe.")
 
 if __name__ == "__main__":
     app.run(host="127.0.0.1", port=5000, debug=True)

--- a/migrations/versions/20250615_add_companion_app_tables.py
+++ b/migrations/versions/20250615_add_companion_app_tables.py
@@ -8,6 +8,9 @@ Create Date: 2025-06-15 13:32:00.000000
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.engine.reflection import Inspector
+import logging
+
+logger = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision = '20250615_companion'
@@ -121,7 +124,7 @@ def upgrade():
         if 'personal_records' not in session_columns:
             op.add_column('session', sa.Column('personal_records', sa.JSON(), nullable=True))
     except Exception as e:
-        print(f"Warning: Could not add session columns: {e}")
+        logger.warning("Could not add session columns: %s", e)
 
 def downgrade():
     # Remove added columns from session


### PR DESCRIPTION
## Summary
- clean up logging in the training session upload route
- log admin creation in migrations via logging instead of prints
- use logger in alembic migration

## Testing
- `python -m py_compile backend/app.py migrations/versions/20250615_add_companion_app_tables.py`


------
https://chatgpt.com/codex/tasks/task_e_684ef46185048331a2e4e42b11f6f668