### PR TITLE
Update docs for new session columns

### DIFF
--- a/docs/README_MIGRACIONES.md
+++ b/docs/README_MIGRACIONES.md
@@ -71,12 +71,23 @@ Desarrollo Local → Railway Dev → Validación → Merge → Railway Prod
 4. **`user_badge`** - Badges desbloqueados por usuario
 
 #### Columnas Añadidas a `session`:
-- `duration_minutes` (Integer)
-- `distance_km` (Float)
-- `falls_count` (Integer)
-- `jibes_count` (Integer)
-- `jumps_count` (Integer)
 
+- `flight_duration` (Integer)
+- `upwind_distance` (Float)
+- `falls_count` (Integer)
+- `max_speed` (Float)
+- `avg_speed` (Float)
+- `tricks_attempted` (Integer)
+- `tricks_landed` (Integer)
+- `water_time` (Integer)
+- `preparation_time` (Integer)
+- `session_type` (String)
+- `motivation_level` (Integer)
+- `energy_level_before` (Integer)
+- `energy_level_after` (Integer)
+- `goals_worked_on` (Text)
+- `personal_bests` (Text)
+ 
 ### Cadena de Dependencias:
 ```
 20250614_add_goal_fields → 20250615_seed_levels → 20250615_companion
@@ -344,7 +355,7 @@ badge (id, name, description, icon, category, criteria, points_value, rarity)
 user_badge (id, user_id, badge_id, unlocked_at)
 
 -- Sesiones extendidas
-session (id, user_id, ..., duration_minutes, distance_km, falls_count, jibes_count, jumps_count)
+session (id, user_id, ..., flight_duration, upwind_distance, falls_count, max_speed, avg_speed, tricks_attempted, tricks_landed, water_time, preparation_time, session_type, motivation_level, energy_level_before, energy_level_after, goals_worked_on, personal_bests)
 ```
 
 ### Relaciones


### PR DESCRIPTION
## Summary
- document updated session columns for the companion tables
- remove references to old columns in migration docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef46a64fc8331afa24d663274fca6